### PR TITLE
Add SMK Karanganyar education management module

### DIFF
--- a/addons/SMK-Karangayar/__init__.py
+++ b/addons/SMK-Karangayar/__init__.py
@@ -1,0 +1,3 @@
+from . import models
+from . import controllers
+from . import report

--- a/addons/SMK-Karangayar/__manifest__.py
+++ b/addons/SMK-Karangayar/__manifest__.py
@@ -1,0 +1,22 @@
+{
+    'name': 'SMK Karanganyar',
+    'version': '16.0.1.0.0',
+    'category': 'Education',
+    'summary': 'Manajemen guru, siswa, kelas, dan tagihan SMK Karanganyar',
+    'author': 'Custom',
+    'depends': ['base', 'mail'],
+    'data': [
+        'security/ir.model.access.csv',
+        'data/sequence.xml',
+        'data/cron.xml',
+        'report/report.xml',
+        'report/guru_report_templates.xml',
+        'report/kwitansi_report_templates.xml',
+        'views/guru_views.xml',
+        'views/siswa_views.xml',
+        'views/kelas_views.xml',
+        'views/invoice_views.xml',
+        'views/menu_views.xml',
+    ],
+    'application': True,
+}

--- a/addons/SMK-Karangayar/controllers/__init__.py
+++ b/addons/SMK-Karangayar/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import main

--- a/addons/SMK-Karangayar/controllers/main.py
+++ b/addons/SMK-Karangayar/controllers/main.py
@@ -1,0 +1,70 @@
+import json
+
+from odoo import http
+from odoo.http import request
+
+
+class SmkApiController(http.Controller):
+    @http.route('/api/smk/guru', type='http', auth='user', methods=['GET'], csrf=False)
+    def api_get_guru(self, **kwargs):
+        gurus = request.env['smk.guru'].sudo().search([])
+        data = []
+        for guru in gurus:
+            data.append({
+                'id': guru.id,
+                'name': guru.name,
+                'address': guru.address,
+                'phone': guru.phone,
+                'student_count': guru.student_count,
+                'students': [
+                    {
+                        'id': siswa.id,
+                        'name': siswa.name,
+                        'class': siswa.kelas_id.name,
+                        'active': siswa.active,
+                    }
+                    for siswa in guru.siswa_ids
+                ],
+            })
+        body = json.dumps({'data': data})
+        headers = [('Content-Type', 'application/json')]
+        return request.make_response(body, headers=headers)
+
+    @http.route('/api/smk/siswa', type='json', auth='user', methods=['POST'], csrf=False)
+    def api_create_siswa(self, **payload):
+        required_fields = ['name']
+        missing = [field for field in required_fields if not payload.get(field)]
+        if missing:
+            return {'error': f"Field {', '.join(missing)} wajib diisi."}
+
+        siswa_vals = {
+            'name': payload.get('name'),
+            'nis': payload.get('nis'),
+            'guru_id': payload.get('guru_id'),
+            'kelas_id': payload.get('kelas_id'),
+            'phone': payload.get('phone'),
+            'address': payload.get('address'),
+        }
+        if siswa_vals['kelas_id'] and not siswa_vals['guru_id']:
+            kelas = request.env['smk.kelas'].sudo().browse(siswa_vals['kelas_id'])
+            if kelas:
+                siswa_vals['guru_id'] = kelas.guru_id.id
+        if not siswa_vals['guru_id'] or not siswa_vals['kelas_id']:
+            return {'error': 'Guru dan kelas wajib diisi.'}
+
+        guru = request.env['smk.guru'].sudo().browse(siswa_vals['guru_id'])
+        kelas = request.env['smk.kelas'].sudo().browse(siswa_vals['kelas_id'])
+        if not guru:
+            return {'error': 'Guru tidak ditemukan.'}
+        if not kelas:
+            return {'error': 'Kelas tidak ditemukan.'}
+        if kelas.guru_id and kelas.guru_id.id != guru.id:
+            return {'error': 'Guru dan kelas tidak sesuai.'}
+
+        siswa = request.env['smk.siswa'].sudo().create(siswa_vals)
+        return {
+            'id': siswa.id,
+            'name': siswa.name,
+            'guru_id': siswa.guru_id.id,
+            'kelas_id': siswa.kelas_id.id,
+        }

--- a/addons/SMK-Karangayar/data/cron.xml
+++ b/addons/SMK-Karangayar/data/cron.xml
@@ -1,0 +1,14 @@
+<odoo>
+    <data noupdate="1">
+        <record id="ir_cron_smk_invoice" model="ir.cron">
+            <field name="name">Generate Monthly Student Invoice</field>
+            <field name="model_id" ref="model_smk_invoice"/>
+            <field name="state">code</field>
+            <field name="code">model.cron_create_monthly_invoice()</field>
+            <field name="active" eval="True"/>
+            <field name="interval_number">1</field>
+            <field name="interval_type">months</field>
+            <field name="numbercall">-1</field>
+        </record>
+    </data>
+</odoo>

--- a/addons/SMK-Karangayar/data/sequence.xml
+++ b/addons/SMK-Karangayar/data/sequence.xml
@@ -1,0 +1,10 @@
+<odoo>
+    <data noupdate="1">
+        <record id="seq_smk_invoice" model="ir.sequence">
+            <field name="name">SMK Invoice Sequence</field>
+            <field name="code">smk.invoice</field>
+            <field name="prefix">INV/%(year)s/</field>
+            <field name="padding">4</field>
+        </record>
+    </data>
+</odoo>

--- a/addons/SMK-Karangayar/models/__init__.py
+++ b/addons/SMK-Karangayar/models/__init__.py
@@ -1,0 +1,4 @@
+from . import guru
+from . import siswa
+from . import kelas
+from . import invoice

--- a/addons/SMK-Karangayar/models/guru.py
+++ b/addons/SMK-Karangayar/models/guru.py
@@ -1,0 +1,38 @@
+from odoo import api, fields, models
+
+
+class SmkGuru(models.Model):
+    _name = 'smk.guru'
+    _description = 'Guru'
+    _inherit = ['mail.thread', 'mail.activity.mixin']
+
+    name = fields.Char(string='Nama', required=True, tracking=True)
+    address = fields.Text(string='Alamat')
+    phone = fields.Char(string='Nomor Telepon', required=True, tracking=True)
+    kelas_ids = fields.One2many('smk.kelas', 'guru_id', string='Kelas')
+    siswa_ids = fields.One2many('smk.siswa', 'guru_id', string='Siswa')
+    student_count = fields.Integer(
+        string='Jumlah Siswa',
+        compute='_compute_student_count',
+        store=True,
+        compute_sudo=True,
+    )
+
+    _sql_constraints = [
+        ('unique_phone', 'unique(phone)', 'Nomor telepon guru harus unik.'),
+    ]
+
+    @api.depends('siswa_ids.active')
+    def _compute_student_count(self):
+        for guru in self:
+            guru.student_count = len(guru.siswa_ids.filtered(lambda s: s.active))
+
+    def action_activate_students(self):
+        self.ensure_one()
+        self.siswa_ids.write({'active': True})
+        return True
+
+    def action_deactivate_students(self):
+        self.ensure_one()
+        self.siswa_ids.write({'active': False})
+        return True

--- a/addons/SMK-Karangayar/models/invoice.py
+++ b/addons/SMK-Karangayar/models/invoice.py
@@ -1,0 +1,63 @@
+from datetime import date
+
+from odoo import api, fields, models
+from odoo.exceptions import UserError
+
+
+class SmkInvoice(models.Model):
+    _name = 'smk.invoice'
+    _description = 'Tagihan Siswa'
+    _inherit = ['mail.thread', 'mail.activity.mixin']
+
+    name = fields.Char(string='Nomor Tagihan', required=True, copy=False, readonly=True, default='New')
+    student_id = fields.Many2one('smk.siswa', string='Siswa', required=True, tracking=True)
+    guru_id = fields.Many2one('smk.guru', string='Guru', related='student_id.guru_id', store=True)
+    kelas_id = fields.Many2one('smk.kelas', string='Kelas', related='student_id.kelas_id', store=True)
+    date_invoice = fields.Date(string='Tanggal Tagihan', default=fields.Date.context_today, tracking=True)
+    amount = fields.Monetary(string='Jumlah', currency_field='currency_id', required=True, tracking=True)
+    currency_id = fields.Many2one('res.currency', default=lambda self: self.env.company.currency_id)
+    state = fields.Selection([
+        ('draft', 'Draft'),
+        ('paid', 'Paid'),
+    ], default='draft', tracking=True)
+    description = fields.Text(string='Keterangan')
+
+    @api.model
+    def create(self, vals):
+        if vals.get('name', 'New') == 'New':
+            vals['name'] = self.env['ir.sequence'].next_by_code('smk.invoice') or 'New'
+        return super().create(vals)
+
+    def action_mark_paid(self):
+        for invoice in self:
+            invoice.state = 'paid'
+        return True
+
+    def action_print_kwitansi(self):
+        if any(invoice.state != 'paid' for invoice in self):
+            raise UserError('Kwitansi hanya dapat dicetak jika status tagihan Paid.')
+        return self.env.ref('SMK-Karangayar.report_smk_kwitansi').report_action(self)
+
+    @api.model
+    def cron_create_monthly_invoice(self):
+        today = fields.Date.context_today(self)
+        start_date = date(today.year, today.month, 1)
+        if today.month == 12:
+            end_date = date(today.year + 1, 1, 1)
+        else:
+            end_date = date(today.year, today.month + 1, 1)
+
+        for student in self.env['smk.siswa'].sudo().search([('active', '=', True)]):
+            exists = self.search_count([
+                ('student_id', '=', student.id),
+                ('date_invoice', '>=', start_date),
+                ('date_invoice', '<', end_date),
+            ])
+            if exists:
+                continue
+            self.create({
+                'student_id': student.id,
+                'amount': 0.0,
+                'description': 'Tagihan bulanan otomatis',
+                'date_invoice': today,
+            })

--- a/addons/SMK-Karangayar/models/kelas.py
+++ b/addons/SMK-Karangayar/models/kelas.py
@@ -1,0 +1,10 @@
+from odoo import fields, models
+
+
+class SmkKelas(models.Model):
+    _name = 'smk.kelas'
+    _description = 'Kelas'
+
+    name = fields.Char(string='Nama Kelas', required=True)
+    guru_id = fields.Many2one('smk.guru', string='Wali Kelas', required=True)
+    siswa_ids = fields.One2many('smk.siswa', 'kelas_id', string='Siswa')

--- a/addons/SMK-Karangayar/models/siswa.py
+++ b/addons/SMK-Karangayar/models/siswa.py
@@ -1,0 +1,20 @@
+from odoo import api, fields, models
+
+
+class SmkSiswa(models.Model):
+    _name = 'smk.siswa'
+    _description = 'Siswa'
+    _inherit = ['mail.thread', 'mail.activity.mixin']
+
+    name = fields.Char(string='Nama', required=True, tracking=True)
+    nis = fields.Char(string='NIS', tracking=True)
+    guru_id = fields.Many2one('smk.guru', string='Guru', tracking=True, required=True)
+    kelas_id = fields.Many2one('smk.kelas', string='Kelas', tracking=True, required=True)
+    phone = fields.Char(string='Nomor Telepon Wali')
+    address = fields.Text(string='Alamat')
+    active = fields.Boolean(default=True)
+
+    @api.onchange('kelas_id')
+    def _onchange_kelas_id(self):
+        if self.kelas_id:
+            self.guru_id = self.kelas_id.guru_id

--- a/addons/SMK-Karangayar/report/__init__.py
+++ b/addons/SMK-Karangayar/report/__init__.py
@@ -1,0 +1,2 @@
+from . import smk_guru_report
+from . import smk_kwitansi_report

--- a/addons/SMK-Karangayar/report/guru_report_templates.xml
+++ b/addons/SMK-Karangayar/report/guru_report_templates.xml
@@ -1,0 +1,41 @@
+<odoo>
+    <template id="report_smk_guru_document">
+        <t t-call="web.html_container">
+            <t t-call="web.external_layout">
+                <div class="page">
+                    <h2>Daftar Guru SMK Karanganyar</h2>
+                    <table class="table table-sm">
+                        <thead>
+                            <tr>
+                                <th>Nama</th>
+                                <th>Alamat</th>
+                                <th>Telepon</th>
+                                <th>Jumlah Siswa Aktif</th>
+                                <th>Siswa</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <t t-foreach="docs" t-as="guru">
+                                <tr>
+                                    <td><span t-field="guru.name"/></td>
+                                    <td><span t-field="guru.address"/></td>
+                                    <td><span t-field="guru.phone"/></td>
+                                    <td><span t-field="guru.student_count"/></td>
+                                    <td>
+                                        <ul>
+                                            <t t-foreach="guru.siswa_ids" t-as="siswa">
+                                                <li>
+                                                    <t t-esc="'%s (%s)' % (siswa.name, siswa.kelas_id.name or '-')"/>
+                                                </li>
+                                            </t>
+                                        </ul>
+                                    </td>
+                                </tr>
+                            </t>
+                        </tbody>
+                    </table>
+                </div>
+            </t>
+        </t>
+    </template>
+</odoo>

--- a/addons/SMK-Karangayar/report/kwitansi_report_templates.xml
+++ b/addons/SMK-Karangayar/report/kwitansi_report_templates.xml
@@ -1,0 +1,76 @@
+<odoo>
+    <template id="report_smk_kwitansi_document">
+        <t t-call="web.html_container">
+            <t t-call="web.external_layout">
+                <t t-foreach="docs" t-as="doc">
+                    <div class="page">
+                        <div class="text-center">
+                            <h3>SMK Karanganyar</h3>
+                            <p>Jl. Lawu, Karanganyar</p>
+                            <p>Email: info@smk-karanganyar.sch.id | Telp: 0271-000000</p>
+                        </div>
+                        <h4 class="text-center">BUKTI PEMBAYARAN SISWA</h4>
+                        <table class="table table-sm">
+                            <tr>
+                                <td>No Trans</td>
+                                <td><span t-field="doc.name"/></td>
+                                <td>Tanggal</td>
+                                <td><span t-field="doc.date_invoice"/></td>
+                            </tr>
+                            <tr>
+                                <td>Nama Siswa</td>
+                                <td><span t-field="doc.student_id.name"/></td>
+                                <td>Kelas</td>
+                                <td><span t-field="doc.kelas_id.name"/></td>
+                            </tr>
+                            <tr>
+                                <td>Guru</td>
+                                <td><span t-field="doc.guru_id.name"/></td>
+                                <td>Status</td>
+                                <td><span t-field="doc.state"/></td>
+                            </tr>
+                        </table>
+
+                        <table class="table table-bordered mt16">
+                            <thead>
+                                <tr>
+                                    <th style="width:5%">No.</th>
+                                    <th>Keterangan Pembayaran</th>
+                                    <th style="width:25%">Jumlah (Rp)</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>1</td>
+                                    <td><span t-esc="doc.description or 'Pembayaran biaya pendidikan'"/></td>
+                                    <td class="text-right"><span t-field="doc.amount" widget="monetary" options="{'display_currency': doc.currency_id}"/></td>
+                                </tr>
+                            </tbody>
+                            <tfoot>
+                                <tr>
+                                    <td colspan="2" class="text-right"><strong>Total</strong></td>
+                                    <td class="text-right"><strong><span t-field="doc.amount" widget="monetary" options="{'display_currency': doc.currency_id}"/></strong></td>
+                                </tr>
+                            </tfoot>
+                        </table>
+
+                        <p><em>Terbilang:</em> <span t-esc="doc.currency_id.amount_to_text(doc.amount)"/></p>
+
+                        <div class="row mt32">
+                            <div class="col-6">
+                                <p>Mengetahui,</p>
+                                <p><span t-field="company.name"/></p>
+                            </div>
+                            <div class="col-6 text-right">
+                                <p>Karanganyar, <span t-esc="doc.date_invoice"/></p>
+                                <p>Yang Menerima,</p>
+                                <br/><br/>
+                                <p>_______________________</p>
+                            </div>
+                        </div>
+                    </div>
+                </t>
+            </t>
+        </t>
+    </template>
+</odoo>

--- a/addons/SMK-Karangayar/report/report.xml
+++ b/addons/SMK-Karangayar/report/report.xml
@@ -1,0 +1,20 @@
+<odoo>
+    <report
+        id="report_smk_guru"
+        model="smk.guru"
+        string="Daftar Guru"
+        report_type="qweb-pdf"
+        name="SMK-Karangayar.report_smk_guru_document"
+        file="SMK-Karangayar.report_smk_guru_document"
+    />
+
+    <report
+        id="report_smk_kwitansi"
+        model="smk.invoice"
+        string="Kwitansi Pembayaran"
+        report_type="qweb-pdf"
+        name="SMK-Karangayar.report_smk_kwitansi_document"
+        file="SMK-Karangayar.report_smk_kwitansi_document"
+        print_report_name="(object.name or 'Kwitansi')"
+    />
+</odoo>

--- a/addons/SMK-Karangayar/report/smk_guru_report.py
+++ b/addons/SMK-Karangayar/report/smk_guru_report.py
@@ -1,0 +1,15 @@
+from odoo import api, models
+
+
+class ReportSmkGuru(models.AbstractModel):
+    _name = 'report.SMK-Karangayar.report_smk_guru_document'
+    _description = 'Laporan Daftar Guru'
+
+    @api.model
+    def _get_report_values(self, docids, data=None):
+        docs = self.env['smk.guru'].browse(docids) if docids else self.env['smk.guru'].search([])
+        return {
+            'doc_ids': docs.ids,
+            'doc_model': 'smk.guru',
+            'docs': docs,
+        }

--- a/addons/SMK-Karangayar/report/smk_kwitansi_report.py
+++ b/addons/SMK-Karangayar/report/smk_kwitansi_report.py
@@ -1,0 +1,17 @@
+from odoo import api, models
+
+
+class ReportSmkKwitansi(models.AbstractModel):
+    _name = 'report.SMK-Karangayar.report_smk_kwitansi_document'
+    _description = 'Laporan Kwitansi SMK'
+
+    @api.model
+    def _get_report_values(self, docids, data=None):
+        docs = self.env['smk.invoice'].browse(docids)
+        company = self.env.company
+        return {
+            'doc_ids': docs.ids,
+            'doc_model': 'smk.invoice',
+            'docs': docs,
+            'company': company,
+        }

--- a/addons/SMK-Karangayar/security/ir.model.access.csv
+++ b/addons/SMK-Karangayar/security/ir.model.access.csv
@@ -1,0 +1,5 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_smk_guru_user,access.smk.guru,model_smk_guru,base.group_user,1,1,1,1
+access_smk_siswa_user,access.smk.siswa,model_smk_siswa,base.group_user,1,1,1,1
+access_smk_kelas_user,access.smk.kelas,model_smk_kelas,base.group_user,1,1,1,1
+access_smk_invoice_user,access.smk.invoice,model_smk_invoice,base.group_user,1,1,1,1

--- a/addons/SMK-Karangayar/views/__init__.py
+++ b/addons/SMK-Karangayar/views/__init__.py
@@ -1,0 +1,1 @@
+# This file intentionally left blank to mark the views package.

--- a/addons/SMK-Karangayar/views/guru_views.xml
+++ b/addons/SMK-Karangayar/views/guru_views.xml
@@ -1,0 +1,58 @@
+<odoo>
+    <record id="view_smk_guru_tree" model="ir.ui.view">
+        <field name="name">smk.guru.tree</field>
+        <field name="model">smk.guru</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name"/>
+                <field name="phone"/>
+                <field name="student_count"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_smk_guru_form" model="ir.ui.view">
+        <field name="name">smk.guru.form</field>
+        <field name="model">smk.guru</field>
+        <field name="arch" type="xml">
+            <form string="Guru">
+                <header>
+                    <button name="action_activate_students" type="object" class="btn-primary" string="Aktifkan Semua Siswa"/>
+                    <button name="action_deactivate_students" type="object" class="btn-secondary" string="Nonaktifkan Semua Siswa"/>
+                </header>
+                <sheet>
+                    <group>
+                        <field name="name"/>
+                        <field name="phone"/>
+                        <field name="address"/>
+                        <field name="student_count" readonly="1"/>
+                    </group>
+                    <notebook>
+                        <page string="Kelas">
+                            <field name="kelas_ids">
+                                <tree editable="bottom">
+                                    <field name="name"/>
+                                </tree>
+                            </field>
+                        </page>
+                        <page string="Siswa">
+                            <field name="siswa_ids">
+                                <tree editable="bottom">
+                                    <field name="name"/>
+                                    <field name="kelas_id"/>
+                                    <field name="active"/>
+                                </tree>
+                            </field>
+                        </page>
+                    </notebook>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_smk_guru" model="ir.actions.act_window">
+        <field name="name">Guru</field>
+        <field name="res_model">smk.guru</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+</odoo>

--- a/addons/SMK-Karangayar/views/invoice_views.xml
+++ b/addons/SMK-Karangayar/views/invoice_views.xml
@@ -1,0 +1,51 @@
+<odoo>
+    <record id="view_smk_invoice_tree" model="ir.ui.view">
+        <field name="name">smk.invoice.tree</field>
+        <field name="model">smk.invoice</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name"/>
+                <field name="student_id"/>
+                <field name="guru_id"/>
+                <field name="kelas_id"/>
+                <field name="date_invoice"/>
+                <field name="amount"/>
+                <field name="state"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_smk_invoice_form" model="ir.ui.view">
+        <field name="name">smk.invoice.form</field>
+        <field name="model">smk.invoice</field>
+        <field name="arch" type="xml">
+            <form string="Tagihan">
+                <header>
+                    <button name="action_mark_paid" type="object" string="Tandai Lunas" states="draft" class="btn-primary"/>
+                    <button name="action_print_kwitansi" type="object" string="Cetak Kwitansi" attrs="{'invisible': [('state', '!=', 'paid')]}"/>
+                </header>
+                <sheet>
+                    <group>
+                        <field name="name" readonly="1"/>
+                        <field name="student_id"/>
+                        <field name="guru_id" readonly="1"/>
+                        <field name="kelas_id" readonly="1"/>
+                        <field name="date_invoice"/>
+                        <field name="amount"/>
+                        <field name="currency_id" readonly="1"/>
+                        <field name="state" readonly="1"/>
+                    </group>
+                    <group>
+                        <field name="description"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_smk_invoice" model="ir.actions.act_window">
+        <field name="name">Tagihan</field>
+        <field name="res_model">smk.invoice</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+</odoo>

--- a/addons/SMK-Karangayar/views/kelas_views.xml
+++ b/addons/SMK-Karangayar/views/kelas_views.xml
@@ -1,0 +1,44 @@
+<odoo>
+    <record id="view_smk_kelas_tree" model="ir.ui.view">
+        <field name="name">smk.kelas.tree</field>
+        <field name="model">smk.kelas</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name"/>
+                <field name="guru_id"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_smk_kelas_form" model="ir.ui.view">
+        <field name="name">smk.kelas.form</field>
+        <field name="model">smk.kelas</field>
+        <field name="arch" type="xml">
+            <form string="Kelas">
+                <sheet>
+                    <group>
+                        <field name="name"/>
+                        <field name="guru_id"/>
+                    </group>
+                    <notebook>
+                        <page string="Siswa">
+                            <field name="siswa_ids">
+                                <tree editable="bottom">
+                                    <field name="name"/>
+                                    <field name="nis"/>
+                                    <field name="active"/>
+                                </tree>
+                            </field>
+                        </page>
+                    </notebook>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_smk_kelas" model="ir.actions.act_window">
+        <field name="name">Kelas</field>
+        <field name="res_model">smk.kelas</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+</odoo>

--- a/addons/SMK-Karangayar/views/menu_views.xml
+++ b/addons/SMK-Karangayar/views/menu_views.xml
@@ -1,0 +1,8 @@
+<odoo>
+    <menuitem id="menu_smk_root" name="SMK Karanganyar" sequence="10"/>
+
+    <menuitem id="menu_smk_guru" name="Guru" parent="menu_smk_root" action="action_smk_guru" sequence="10"/>
+    <menuitem id="menu_smk_siswa" name="Siswa" parent="menu_smk_root" action="action_smk_siswa" sequence="20"/>
+    <menuitem id="menu_smk_kelas" name="Kelas" parent="menu_smk_root" action="action_smk_kelas" sequence="30"/>
+    <menuitem id="menu_smk_invoice" name="Tagihan" parent="menu_smk_root" action="action_smk_invoice" sequence="40"/>
+</odoo>

--- a/addons/SMK-Karangayar/views/siswa_views.xml
+++ b/addons/SMK-Karangayar/views/siswa_views.xml
@@ -1,0 +1,41 @@
+<odoo>
+    <record id="view_smk_siswa_tree" model="ir.ui.view">
+        <field name="name">smk.siswa.tree</field>
+        <field name="model">smk.siswa</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name"/>
+                <field name="nis"/>
+                <field name="guru_id"/>
+                <field name="kelas_id"/>
+                <field name="active"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_smk_siswa_form" model="ir.ui.view">
+        <field name="name">smk.siswa.form</field>
+        <field name="model">smk.siswa</field>
+        <field name="arch" type="xml">
+            <form string="Siswa">
+                <sheet>
+                    <group>
+                        <field name="name"/>
+                        <field name="nis"/>
+                        <field name="kelas_id"/>
+                        <field name="guru_id"/>
+                        <field name="phone"/>
+                        <field name="address"/>
+                        <field name="active"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_smk_siswa" model="ir.actions.act_window">
+        <field name="name">Siswa</field>
+        <field name="res_model">smk.siswa</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Summary
- add a custom SMK Karanganyar module with models for teachers, students, classes, and invoices including automatic student counts and validations
- provide user interfaces, PDF reports, and automation for monthly invoicing with receipt printing when invoices are paid
- expose API endpoints to list teachers and create students programmatically

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e5a878a9fc832bad4b2c7271e695f6